### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "matten"
 version = "0.0.1"
 readme = "README.md"
-requires-python = ">=3.8, <3.11"
+requires-python = ">=3.10, <3.11"
 dependencies = [
-#    "pytorch-lightning>1.7.0, <1.9.0",
-#    "lightning-bolts>=0.6.0",
-#    "torchmetrics>=0.10.0",
-#    "torch_geometric",
+    "pytorch-lightning>1.7.0, <1.9.0",
+    "lightning-bolts>=0.6.0",
+    "torchmetrics>=0.10.0,<1.0.0",
+    "torch_geometric",
+    "torch_scatter",
     "e3nn",
     "ase",
     "pymatgen",


### PR DESCRIPTION
Hi @mjwen, just a small update to the `pyproject.toml` so that the example in the `README.md` can run:

* Python >= 3.10 is required, but only for the type hint syntax. If `Union` instead of `|` was used (and perhaps, `List` instead of `list`?), I think it would still work in lower Python versions.
* `torch_scatter` was missing from the dependencies
* `torch_metrics` >= 1.0.0 gives a ``ValueError: Unexpected keyword arguments: `compute_on_step` `` error, I'm not sure what this is or how to resolve, so I pinned it to < 1.0.0 for now, but this is probably not ideal.

For debugging, this is my full `pip freeze` for a working example on Python 3.10:

```
absl-py==1.4.0
aiohttp==3.8.5
aiosignal==1.3.1
ase==3.22.1
asttokens==2.2.1
async-timeout==4.0.2
attrs==23.1.0
backcall==0.2.0
cachetools==5.3.1
certifi==2023.7.22
charset-normalizer==3.2.0
cmake==3.27.1
contourpy==1.1.0
cycler==0.11.0
decorator==5.1.1
e3nn==0.5.1
emmet-core==0.64.0
executing==1.2.0
filelock==3.12.2
fonttools==4.42.0
frozenlist==1.4.0
fsspec==2023.6.0
future==0.18.3
google-auth==2.22.0
google-auth-oauthlib==1.0.0
grpcio==1.56.2
idna==3.4
ipython==8.14.0
jedi==0.19.0
Jinja2==3.1.2
joblib==1.3.2
kiwisolver==1.4.4
latexcodec==2.0.1
lightning-bolts==0.7.0
lightning-utilities==0.9.0
lit==16.0.6
loguru==0.7.0
Markdown==3.4.4
MarkupSafe==2.1.3
matplotlib==3.7.2
matplotlib-inline==0.1.6
-e git+https://github.com/wengroup/matten.git@73f7330a1689166ea603d819eab39a3f3c7c30d5#egg=matten
monty==2023.8.8
mp-api==0.33.3
mpmath==1.3.0
msgpack==1.0.5
multidict==6.0.4
networkx==3.1
numpy==1.25.2
nvidia-cublas-cu11==11.10.3.66
nvidia-cuda-cupti-cu11==11.7.101
nvidia-cuda-nvrtc-cu11==11.7.99
nvidia-cuda-runtime-cu11==11.7.99
nvidia-cudnn-cu11==8.5.0.96
nvidia-cufft-cu11==10.9.0.58
nvidia-curand-cu11==10.2.10.91
nvidia-cusolver-cu11==11.4.0.1
nvidia-cusparse-cu11==11.7.4.91
nvidia-nccl-cu11==2.14.3
nvidia-nvtx-cu11==11.7.91
oauthlib==3.2.2
opt-einsum==3.3.0
opt-einsum-fx==0.1.4
packaging==23.1
palettable==3.3.3
pandas==2.0.3
parso==0.8.3
pexpect==4.8.0
pickleshare==0.7.5
Pillow==10.0.0
plotly==5.15.0
prompt-toolkit==3.0.39
protobuf==4.24.0
psutil==5.9.5
ptyprocess==0.7.0
pure-eval==0.2.2
pyasn1==0.5.0
pyasn1-modules==0.3.0
pybtex==0.24.0
pydantic==1.10.12
Pygments==2.16.1
pymatgen==2023.7.20
pyparsing==3.0.9
python-dateutil==2.8.2
pytorch-lightning==1.9.5
pytz==2023.3
PyYAML==6.0.1
requests==2.31.0
requests-oauthlib==1.3.1
rsa==4.9
ruamel.yaml==0.17.32
ruamel.yaml.clib==0.2.7
scikit-learn==1.3.0
scipy==1.11.1
six==1.16.0
spglib==2.0.2
stack-data==0.6.2
sympy==1.12
tabulate==0.9.0
tenacity==8.2.2
tensorboard==2.14.0
tensorboard-data-server==0.7.1
threadpoolctl==3.2.0
torch==2.0.1
torch-geometric==2.3.1
torch-scatter==2.1.1
torchmetrics==0.11.4
torchtyping==0.1.4
torchvision==0.15.2
tqdm==4.66.0
traitlets==5.9.0
triton==2.0.0
typeguard==4.1.0
typing_extensions==4.7.1
tzdata==2023.3
uncertainties==3.1.7
urllib3==1.26.16
wcwidth==0.2.6
Werkzeug==2.3.6
yarl==1.9.2
```